### PR TITLE
Integer format samples can be either 32 bits or 16 bits length.

### DIFF
--- a/GeoTiffCOG/Struture/FileMetaData.cs
+++ b/GeoTiffCOG/Struture/FileMetaData.cs
@@ -78,6 +78,8 @@ namespace GeoTiffCOG.Struture
         public float MinimumAltitude { get; set; }
         public float MaximumAltitude { get; set; }
 
+        public float Offset { get; set; }
+        public float Scale { get; set; }
 
         private float _noDataValue;
         private bool _noDataValueSet = false;


### PR DESCRIPTION
Integer format samples can be either 32 bits or 16 bits length.
For integers we need to consider the scale factor and offset value found in the GDAL Metadata.
